### PR TITLE
Feature/stage2 pairing

### DIFF
--- a/docs/stage2_pairing_analysis.md
+++ b/docs/stage2_pairing_analysis.md
@@ -1,0 +1,51 @@
+# Stage 2: Aspect-Opinion Pairing — Design Decision
+
+## Decision: heuristic, not learned
+
+A distance-based heuristic pairer is used instead of a trained neural
+classifier, based on data analysis (not assumption):
+
+| Metric (train split, explicit-both quads) | Value |
+|---|---|
+| Sentences with any pairing ambiguity (candidates > true pairs) | 331 / 39,261 (0.84%) |
+| Total negative candidate pairs | 704 (out of 24,146 total candidates) |
+| True-pair median token distance | 1 |
+| False-pair median token distance | 6 |
+| Quads with exactly 1 opinion per aspect | 99.1% |
+| Quads with exactly 1 aspect per opinion | 99.4% |
+
+With only 704 negative examples spread across 39k sentences, there isn't
+enough signal to train a reliable neural classifier — and the heuristic
+already achieves near-ceiling performance:
+
+| Split | Precision | Recall | F1 |
+|---|---|---|---|
+| Train | 0.9889 | 0.9976 | 0.9932 |
+| Test | 0.9883 | 0.9976 | 0.9929 |
+
+Matching train/test performance (no gap) confirms this isn't overfitting —
+there's nothing to overfit, it's a fixed rule.
+
+## How it works
+
+For each aspect span, pair it with its nearest opinion span(s) by token
+distance (ties included); do the same in reverse (each opinion → nearest
+aspect). Take the union. See `candidates.py::heuristic_pairs`.
+
+## Important caveat for Stage 6
+
+This evaluates pairing **in isolation using gold spans**. End-to-end
+pipeline performance will still be bottlenecked by Stage 1's span
+extraction quality (aspect F1 ~0.60, opinion F1 ~0.46 as of the AfroXLMR
+baseline) — a missed or wrong span means no correct pair is possible
+regardless of how good the pairing logic is. The isolated 0.993 F1 here is
+a ceiling for Stage 2 alone, not a preview of the full pipeline number.
+
+## If ambiguity matters more in future data
+
+If a future dataset revision has meaningfully more multi-quad sentences,
+revisit this decision — the heuristic's blind spot is genuine semantic
+ambiguity (e.g. two aspects, two opinions, but the *nearest* opinion isn't
+the *correct* one), which a learned model could in principle resolve given
+enough training examples. At current data volumes, that's not a fixable gap
+with more model capacity — it's a data volume gap.

--- a/src/stage2_pairing/candidates.py
+++ b/src/stage2_pairing/candidates.py
@@ -1,0 +1,89 @@
+"""
+Stage 2: aspect-opinion pairing.
+
+Scope: EXPLICIT spans only. A quad where either the aspect or opinion is
+implicit (-1,-1) is excluded here -- that's Stage 5's job (implicit
+detection needs to both find AND place implicit terms; keeping that logic
+together rather than split across stages).
+
+This module builds candidate (aspect_span, opinion_span) pairs per sentence
+plus their gold labels, and a distance-based heuristic pairer -- see
+docs/stage2_pairing_analysis.md for why the heuristic is the primary
+approach here rather than a learned classifier: >99% of quads are 1:1
+aspect<->opinion mappings, real pairing ambiguity occurs in <1% of
+sentences, and true pairs sit at a median token distance of 1 vs. 6 for
+false candidates. There simply isn't enough negative signal in the data
+(704 negative pairs total across 39k training sentences) to train a neural
+classifier that would reliably beat this heuristic.
+"""
+from dataclasses import dataclass
+
+
+@dataclass
+class PairExample:
+    aspect_span: tuple[int, int]
+    opinion_span: tuple[int, int]
+    label: int  # 1 = true pair (co-occur in some quad), 0 = false candidate
+
+
+def explicit_quads(quads: list[dict]) -> list[dict]:
+    return [q for q in quads if q["a_start"] != -1 and q["o_start"] != -1]
+
+
+def build_candidates(quads: list[dict]) -> list[PairExample]:
+    """All (aspect_span, opinion_span) candidate pairs for one sentence,
+    with gold labels, restricted to explicit-both quads."""
+    ex_quads = explicit_quads(quads)
+    if not ex_quads:
+        return []
+
+    aspect_spans = sorted(set((q["a_start"], q["a_end"]) for q in ex_quads))
+    opinion_spans = sorted(set((q["o_start"], q["o_end"]) for q in ex_quads))
+    true_pairs = set((q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads)
+
+    examples = []
+    for a_span in aspect_spans:
+        for o_span in opinion_spans:
+            label = 1 if (*a_span, *o_span) in true_pairs else 0
+            examples.append(PairExample(a_span, o_span, label))
+    return examples
+
+
+def span_distance(a_span: tuple[int, int], o_span: tuple[int, int]) -> int:
+    """Minimum token-index distance between the two spans' endpoints."""
+    a1, a2 = a_span
+    o1, o2 = o_span
+    return min(abs(a1 - o1), abs(a1 - o2), abs(a2 - o1), abs(a2 - o2))
+
+
+def heuristic_pairs(
+    aspect_spans: list[tuple[int, int]],
+    opinion_spans: list[tuple[int, int]],
+) -> set[tuple[int, int, int, int]]:
+    """Nearest-token-distance pairing, symmetric union:
+    - each aspect paired with its nearest opinion span(s) (ties included)
+    - each opinion paired with its nearest aspect span(s) (ties included)
+    Union of both directions -- gives a little extra recall on the rare
+    one-to-many cases without much precision cost, since both directions
+    are still constrained to "nearest", not arbitrary pairing.
+    """
+    if not aspect_spans or not opinion_spans:
+        return set()
+
+    pairs = set()
+
+    for a_span in aspect_spans:
+        dists = [(span_distance(a_span, o_span), o_span) for o_span in opinion_spans]
+        min_d = min(d for d, _ in dists)
+        for d, o_span in dists:
+            if d == min_d:
+                pairs.add((*a_span, *o_span))
+
+    for o_span in opinion_spans:
+        dists = [(span_distance(a_span, o_span), a_span) for a_span in aspect_spans]
+        min_d = min(d for d, _ in dists)
+        for d, a_span in dists:
+            if d == min_d:
+                pairs.add((*a_span, *o_span))
+
+    return pairs

--- a/src/stage2_pairing/candidates.py
+++ b/src/stage2_pairing/candidates.py
@@ -37,9 +37,9 @@ def build_candidates(quads: list[dict]) -> list[PairExample]:
     if not ex_quads:
         return []
 
-    aspect_spans = sorted(set((q["a_start"], q["a_end"]) for q in ex_quads))
-    opinion_spans = sorted(set((q["o_start"], q["o_end"]) for q in ex_quads))
-    true_pairs = set((q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads)
+    aspect_spans = sorted({(q["a_start"], q["a_end"]) for q in ex_quads})
+    opinion_spans = sorted({(q["o_start"], q["o_end"]) for q in ex_quads})
+    true_pairs = {(q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads}
 
     examples = []
     for a_span in aspect_spans:

--- a/src/stage2_pairing/evaluate.py
+++ b/src/stage2_pairing/evaluate.py
@@ -28,9 +28,9 @@ def evaluate(path: str) -> dict:
             continue
         n_sentences += 1
 
-        aspect_spans = sorted(set((q["a_start"], q["a_end"]) for q in ex_quads))
-        opinion_spans = sorted(set((q["o_start"], q["o_end"]) for q in ex_quads))
-        true_pairs = set((q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads)
+        aspect_spans = sorted({(q["a_start"], q["a_end"]) for q in ex_quads})
+        opinion_spans = sorted({(q["o_start"], q["o_end"]) for q in ex_quads})
+        true_pairs = {(q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads}
 
         pred_pairs = heuristic_pairs(aspect_spans, opinion_spans)
 

--- a/src/stage2_pairing/evaluate.py
+++ b/src/stage2_pairing/evaluate.py
@@ -21,22 +21,23 @@ def evaluate(path: str) -> dict:
     tp = fp = fn = 0
     n_sentences = 0
 
-    for line in open(path, encoding="utf-8"):
-        rec = json.loads(line)
-        ex_quads = explicit_quads(rec["quads"])
-        if not ex_quads:
-            continue
-        n_sentences += 1
+    with open(path, encoding="utf-8") as data:
+        for line in data:
+            rec = json.loads(line)
+            ex_quads = explicit_quads(rec["quads"])
+            if not ex_quads:
+                continue
+            n_sentences += 1
 
-        aspect_spans = sorted({(q["a_start"], q["a_end"]) for q in ex_quads})
-        opinion_spans = sorted({(q["o_start"], q["o_end"]) for q in ex_quads})
-        true_pairs = {(q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads}
+            aspect_spans = sorted({(q["a_start"], q["a_end"]) for q in ex_quads})
+            opinion_spans = sorted({(q["o_start"], q["o_end"]) for q in ex_quads})
+            true_pairs = {(q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads}
 
-        pred_pairs = heuristic_pairs(aspect_spans, opinion_spans)
+            pred_pairs = heuristic_pairs(aspect_spans, opinion_spans)
 
-        tp += len(pred_pairs & true_pairs)
-        fp += len(pred_pairs - true_pairs)
-        fn += len(true_pairs - pred_pairs)
+            tp += len(pred_pairs & true_pairs)
+            fp += len(pred_pairs - true_pairs)
+            fn += len(true_pairs - pred_pairs)
 
     precision = tp / (tp + fp) if (tp + fp) else 0.0
     recall = tp / (tp + fn) if (tp + fn) else 0.0

--- a/src/stage2_pairing/evaluate.py
+++ b/src/stage2_pairing/evaluate.py
@@ -1,0 +1,61 @@
+"""
+Stage 2 evaluation: heuristic aspect-opinion pairing against gold spans.
+
+Usage:
+    python evaluate.py --data ../../data/prepared/test.jsonl
+
+Note: this evaluates pairing IN ISOLATION using gold (not predicted) spans --
+it measures whether the pairing logic itself is correct, not end-to-end
+pipeline performance. Real pipeline F1 will additionally be bottlenecked by
+Stage 1's span extraction errors (a missed or wrong span means no correct
+pair is possible regardless of pairing quality) -- that combined number
+belongs in Stage 6's end-to-end evaluation, not here.
+"""
+import argparse
+import json
+
+from candidates import explicit_quads, heuristic_pairs
+
+
+def evaluate(path: str) -> dict:
+    tp = fp = fn = 0
+    n_sentences = 0
+
+    for line in open(path, encoding="utf-8"):
+        rec = json.loads(line)
+        ex_quads = explicit_quads(rec["quads"])
+        if not ex_quads:
+            continue
+        n_sentences += 1
+
+        aspect_spans = sorted(set((q["a_start"], q["a_end"]) for q in ex_quads))
+        opinion_spans = sorted(set((q["o_start"], q["o_end"]) for q in ex_quads))
+        true_pairs = set((q["a_start"], q["a_end"], q["o_start"], q["o_end"]) for q in ex_quads)
+
+        pred_pairs = heuristic_pairs(aspect_spans, opinion_spans)
+
+        tp += len(pred_pairs & true_pairs)
+        fp += len(pred_pairs - true_pairs)
+        fn += len(true_pairs - pred_pairs)
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+    return {
+        "sentences_evaluated": n_sentences,
+        "tp": tp, "fp": fp, "fn": fn,
+        "precision": precision, "recall": recall, "f1": f1,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", required=True)
+    args = ap.parse_args()
+
+    metrics = evaluate(args.data)
+    print(json.dumps(metrics, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stage2_pairing.py
+++ b/tests/test_stage2_pairing.py
@@ -1,0 +1,48 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "stage2_pairing"))
+from candidates import explicit_quads, build_candidates, span_distance, heuristic_pairs
+
+
+def test_explicit_quads_filters_implicit():
+    quads = [
+        {"a_start": 0, "a_end": 1, "o_start": 2, "o_end": 3, "category": "X", "sentiment": "POSITIVE"},
+        {"a_start": -1, "a_end": -1, "o_start": 2, "o_end": 3, "category": "X", "sentiment": "POSITIVE"},
+    ]
+    result = explicit_quads(quads)
+    assert len(result) == 1
+    assert result[0]["a_start"] == 0
+
+
+def test_span_distance():
+    assert span_distance((0, 1), (2, 3)) == 1  # a_end=1 to o_start=2
+    assert span_distance((5, 6), (5, 6)) == 0  # identical span
+
+
+def test_heuristic_pairs_simple_case():
+    # one aspect, one opinion -> trivially paired
+    aspect_spans = [(0, 1)]
+    opinion_spans = [(3, 4)]
+    pairs = heuristic_pairs(aspect_spans, opinion_spans)
+    assert pairs == {(0, 1, 3, 4)}
+
+
+def test_heuristic_pairs_picks_nearest():
+    # realistic ambiguous shape: 2 aspects, 2 opinions, each aspect closer to
+    # one specific opinion than the other (mirrors the (2,2) shape that makes
+    # up the vast majority of real ambiguous sentences in the dataset)
+    aspect_spans = [(0, 1), (20, 21)]
+    opinion_spans = [(2, 3), (19, 20)]
+    pairs = heuristic_pairs(aspect_spans, opinion_spans)
+    assert (0, 1, 2, 3) in pairs        # aspect@0 nearest to opinion@2
+    assert (20, 21, 19, 20) in pairs    # aspect@20 nearest to opinion@19
+    assert (0, 1, 19, 20) not in pairs  # far cross-pair should not appear
+    assert (20, 21, 2, 3) not in pairs
+
+
+def test_build_candidates_label_correctness():
+    quads = [
+        {"a_start": 0, "a_end": 1, "o_start": 2, "o_end": 3, "category": "X", "sentiment": "POSITIVE"},
+    ]
+    examples = build_candidates(quads)
+    assert len(examples) == 1
+    assert examples[0].label == 1

--- a/tests/test_stage2_pairing.py
+++ b/tests/test_stage2_pairing.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys
+import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "stage2_pairing"))
 from candidates import explicit_quads, build_candidates, span_distance, heuristic_pairs
 

--- a/tests/test_stage2_pairing.py
+++ b/tests/test_stage2_pairing.py
@@ -1,7 +1,8 @@
-import sys
 import os
+import sys
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "stage2_pairing"))
-from candidates import explicit_quads, build_candidates, span_distance, heuristic_pairs
+from candidates import build_candidates, explicit_quads, heuristic_pairs, span_distance
 
 
 def test_explicit_quads_filters_implicit():


### PR DESCRIPTION
## What this PR does
merges stage 2

## Related issue
Closes #11 

## How it was tested
python src/stage2_pairing/evaluate.py --data data/prepared/train.jsonl

## Checklist
- [ ] Tests pass locally (`pytest tests/`)
- [ ] Config/results committed if this is an experiment
- [ ] README/docs updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added distance-based pairing for explicit aspect and opinion spans.
  - Added candidate generation and pairing evaluation with precision, recall, and F1 metrics.
  - Nearest-span ties are supported, with results combined from both pairing directions.

- **Documentation**
  - Documented the pairing approach, supporting metrics, limitations, and criteria for future review.

- **Tests**
  - Added coverage for explicit-span filtering, span distances, candidate labels, and ambiguous pairing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->