### PR TITLE
feat(stage3): build 22-class category classification head

### DIFF
--- a/configs/stage3_afroxlmr.yaml
+++ b/configs/stage3_afroxlmr.yaml
@@ -1,0 +1,31 @@
+# Stage 3 — category classification (22-class, class-weighted)
+# Swap model_name once the Stage 1 model comparison (AfroXLMR / bert-small /
+# roberta-base-amharic) is finalized -- this defaults to AfroXLMR-base as
+# the strongest general-purpose baseline so far.
+
+model_name: Davlan/afro-xlmr-base
+
+data:
+  train: data/prepared/train.jsonl
+  test: data/prepared/test.jsonl
+  label_space: data/prepared/label_space.json
+  max_length: 256
+
+training:
+  epochs: 10
+  batch_size: 16
+  lr: 2.0e-5
+  warmup_ratio: 0.1
+  seed: 42
+  class_weight_cap: 15.0   # inverse-frequency weighting, capped to avoid
+                            # runaway weights on the 1-2 example categories
+
+output_dir: results/stage3/afroxlmr_base_run1
+
+notes: >
+  Trains on explicit-both quads only (23,617 examples). 2 of the 22
+  categories (PUBLIC_SERVICES#COMMUNITY_SUPPORT,
+  PUBLIC_SERVICES#INFRASTRUCTURE) have zero examples in this subset --
+  see docs/stage3_category_analysis.md. Report per-category P/R/F1, not
+  just macro/micro averages -- with this much imbalance, averages hide
+  the categories that actually need attention.

--- a/docs/stage3_category_analysis.md
+++ b/docs/stage3_category_analysis.md
@@ -1,0 +1,39 @@
+# Stage 3: Category Classification — Design & Architecture
+
+## Overview
+
+Stage 3 classifies each candidate aspect-opinion pair into one of the **22 fixed categories** defined in `label_space.json`.
+
+- **Input**: A sentence with word-level tokens, an aspect span $(a_{start}, a_{end})$, and an opinion span $(o_{start}, o_{end})$.
+- **Scope**: Explicit-both pairs ($a_{start} \neq -1$ and $o_{start} \neq -1$). Implicit aspect/opinion handling is deferred to Stage 5.
+- **Output**: Category label ID $\in [0, 21]$.
+
+---
+
+## Model Architecture
+
+The classifier (`PairClassifier` in `src/stage3_category/model.py`) uses a shared transformer encoder:
+
+1. **Subword Masking**: Binary masks are constructed over the subwords for the aspect span, the opinion span, and the full sentence attention mask.
+2. **Masked Mean Pooling**:
+   $$\mathbf{h}_{\text{aspect}} = \text{MeanPool}(\mathbf{H}, \mathbf{M}_{\text{aspect}})$$
+   $$\mathbf{h}_{\text{opinion}} = \text{MeanPool}(\mathbf{H}, \mathbf{M}_{\text{opinion}})$$
+   $$\mathbf{h}_{\text{sentence}} = \text{MeanPool}(\mathbf{H}, \mathbf{M}_{\text{attention}})$$
+3. **Representation Fusion**: Concatenates all three representations:
+   $$\mathbf{h}_{\text{pair}} = [\mathbf{h}_{\text{aspect}} \,;\, \mathbf{h}_{\text{opinion}} \,;\, \mathbf{h}_{\text{sentence}}] \in \mathbb{R}^{3 \times d_{\text{hidden}}}$$
+4. **Classification Head**:
+   $$\text{logits} = \mathbf{W}_2 \cdot \text{Dropout}(\text{ReLU}(\mathbf{W}_1 \mathbf{h}_{\text{pair}}))$$
+
+This architecture is modular and reused for Stage 4 (Sentiment Classification).
+
+---
+
+## Class Imbalance & Weighting
+
+The 22-category taxonomy exhibits strong class imbalance across the dataset (e.g., `GOVERNANCE#TRANSPARENCY` accounts for ~25% of training quads, while 10 categories have low support $<30$ examples, and 2 categories have 0 examples in the explicit subset).
+
+To stabilize training and ensure minority classes receive learning signal without exploding gradients, we apply capped inverse-frequency class weighting (`compute_class_weights` in `src/common/pair_utils.py`):
+
+$$w_c = \min\left(\frac{N_{\text{total}}}{C \times N_c}, \, \text{cap}\right)$$
+
+Default cap is set to $15.0$.

--- a/src/common/pair_utils.py
+++ b/src/common/pair_utils.py
@@ -1,0 +1,44 @@
+"""
+Shared utilities for span-pair classification tasks (Stage 3: category,
+Stage 4: sentiment). Both stages classify a (sentence, aspect_span,
+opinion_span) triple -- only the label field and output classes differ.
+"""
+
+
+def explicit_quads(quads: list[dict]) -> list[dict]:
+    """Quads where both aspect and opinion are explicit spans (not -1,-1).
+    Stage 3/4 only train on these -- implicit cases are Stage 5's job."""
+    return [q for q in quads if q["a_start"] != -1 and q["o_start"] != -1]
+
+
+def word_span_to_subword_range(word_ids: list, start: int, end: int) -> tuple[int, int] | None:
+    """Map a word-level span [start, end) to the (min, max) subword token
+    indices covering it, using a fast tokenizer's word_ids(). Returns None
+    if the span falls entirely outside the tokenizer's truncation window
+    (rare -- only affects sentences longer than max_length)."""
+    positions = [i for i, wid in enumerate(word_ids) if wid is not None and start <= wid < end]
+    if not positions:
+        return None
+    return min(positions), max(positions)
+
+
+def build_span_mask(seq_len: int, subword_range: tuple[int, int] | None) -> list[int]:
+    """Binary mask over subword positions, 1 for tokens inside the span."""
+    mask = [0] * seq_len
+    if subword_range is None:
+        return mask
+    lo, hi = subword_range
+    for i in range(lo, hi + 1):
+        mask[i] = 1
+    return mask
+
+
+def compute_class_weights(label_counts: dict, num_classes: int, cap: float = 15.0) -> dict:
+    """Inverse-frequency class weights, capped to avoid runaway weights on
+    near-zero-count classes destabilizing training."""
+    total = sum(label_counts.values())
+    weights = {}
+    for label, count in label_counts.items():
+        w = total / (num_classes * count) if count > 0 else cap
+        weights[label] = min(w, cap)
+    return weights

--- a/src/stage1_tagging/dataset.py
+++ b/src/stage1_tagging/dataset.py
@@ -14,8 +14,8 @@ COMMON_DIR = Path(__file__).resolve().parent.parent / "common"
 if str(COMMON_DIR) not in sys.path:
     sys.path.insert(0, str(COMMON_DIR))
 
-from align import align_labels_to_subwords  # noqa: E402
-from bio_labels import build_word_bio  # noqa: E402
+from align import align_labels_to_subwords
+from bio_labels import build_word_bio
 
 
 class TaggingDataset(Dataset):

--- a/src/stage1_tagging/dataset.py
+++ b/src/stage1_tagging/dataset.py
@@ -14,8 +14,8 @@ COMMON_DIR = Path(__file__).resolve().parent.parent / "common"
 if str(COMMON_DIR) not in sys.path:
     sys.path.insert(0, str(COMMON_DIR))
 
-from align import IGNORE_INDEX, align_labels_to_subwords
-from bio_labels import build_word_bio
+from align import align_labels_to_subwords  # noqa: E402
+from bio_labels import build_word_bio  # noqa: E402
 
 
 class TaggingDataset(Dataset):

--- a/src/stage1_tagging/model.py
+++ b/src/stage1_tagging/model.py
@@ -1,7 +1,6 @@
 """
 Shared-encoder, dual-head token classification model for joint ATE + OTE.
 """
-import torch
 from torch import nn
 from transformers import AutoConfig, AutoModel
 

--- a/src/stage1_tagging/train.py
+++ b/src/stage1_tagging/train.py
@@ -38,14 +38,14 @@ for p in [str(STAGE1_DIR), str(COMMON_DIR), str(STAGE1_DIR.parent)]:
         sys.path.insert(0, p)
 
 try:
-    from dataset import TaggingDataset, collate_fn  # noqa: E402
-    from model import JointTaggingModel  # noqa: E402
+    from dataset import TaggingDataset, collate_fn
+    from model import JointTaggingModel
 except ImportError:
-    from dataset_tagging import TaggingDataset, collate_fn  # noqa: E402
-    from model_tagging import JointTaggingModel  # noqa: E402
+    from dataset_tagging import TaggingDataset, collate_fn
+    from model_tagging import JointTaggingModel
 
-from align import decode_subword_predictions  # noqa: E402
-from bio_labels import decode_bio_spans  # noqa: E402
+from align import decode_subword_predictions
+from bio_labels import decode_bio_spans
 
 
 def span_prf(pred_spans_per_ex, gold_spans_per_ex):

--- a/src/stage1_tagging/train.py
+++ b/src/stage1_tagging/train.py
@@ -38,14 +38,14 @@ for p in [str(STAGE1_DIR), str(COMMON_DIR), str(STAGE1_DIR.parent)]:
         sys.path.insert(0, p)
 
 try:
-    from dataset import TaggingDataset, collate_fn
-    from model import JointTaggingModel
+    from dataset import TaggingDataset, collate_fn  # noqa: E402
+    from model import JointTaggingModel  # noqa: E402
 except ImportError:
-    from dataset_tagging import TaggingDataset, collate_fn
-    from model_tagging import JointTaggingModel
+    from dataset_tagging import TaggingDataset, collate_fn  # noqa: E402
+    from model_tagging import JointTaggingModel  # noqa: E402
 
-from align import decode_subword_predictions
-from bio_labels import decode_bio_spans
+from align import decode_subword_predictions  # noqa: E402
+from bio_labels import decode_bio_spans  # noqa: E402
 
 
 def span_prf(pred_spans_per_ex, gold_spans_per_ex):

--- a/src/stage3_category/dataset.py
+++ b/src/stage3_category/dataset.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
-from pair_utils import build_span_mask, explicit_quads, word_span_to_subword_range
+from pair_utils import build_span_mask, explicit_quads, word_span_to_subword_range  # noqa: E402
 
 
 class CategoryPairDataset(Dataset):

--- a/src/stage3_category/dataset.py
+++ b/src/stage3_category/dataset.py
@@ -6,14 +6,18 @@ docs/stage3_category_analysis.md for why 2 of the 22 categories
 zero examples here and are structurally deferred to Stage 5.
 """
 import json
-import torch
-from torch.utils.data import Dataset
-
 import os
 import sys
 
+import torch
+from torch.utils.data import Dataset
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
-from pair_utils import build_span_mask, explicit_quads, word_span_to_subword_range  # noqa: E402
+from pair_utils import (
+    build_span_mask,
+    explicit_quads,
+    word_span_to_subword_range,
+)
 
 
 class CategoryPairDataset(Dataset):

--- a/src/stage3_category/dataset.py
+++ b/src/stage3_category/dataset.py
@@ -1,0 +1,71 @@
+"""
+Stage 3 dataset: category classification over (sentence, aspect_span,
+opinion_span) triples. Trains only on explicit-both quads -- see
+docs/stage3_category_analysis.md for why 2 of the 22 categories
+(PUBLIC_SERVICES#COMMUNITY_SUPPORT, PUBLIC_SERVICES#INFRASTRUCTURE) have
+zero examples here and are structurally deferred to Stage 5.
+"""
+import json
+import torch
+from torch.utils.data import Dataset
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
+from pair_utils import build_span_mask, explicit_quads, word_span_to_subword_range
+
+
+class CategoryPairDataset(Dataset):
+    def __init__(self, jsonl_path: str, tokenizer, label2id: dict, max_length: int = 256):
+        self.tokenizer = tokenizer
+        self.label2id = label2id
+        self.max_length = max_length
+        self.examples = []  # (tokens, a_span, o_span, label_id)
+        self.skipped_truncated = 0
+        self.skipped_unknown_label = 0
+
+        with open(jsonl_path, encoding="utf-8") as f:
+            for line in f:
+                rec = json.loads(line)
+                tokens = rec["tokens"]
+                for q in explicit_quads(rec["quads"]):
+                    if q["category"] not in label2id:
+                        self.skipped_unknown_label += 1
+                        continue
+                    self.examples.append((
+                        tokens,
+                        (q["a_start"], q["a_end"]),
+                        (q["o_start"], q["o_end"]),
+                        label2id[q["category"]],
+                    ))
+
+    def __len__(self):
+        return len(self.examples)
+
+    def __getitem__(self, idx):
+        tokens, a_span, o_span, label_id = self.examples[idx]
+
+        enc = self.tokenizer(
+            tokens, is_split_into_words=True, truncation=True,
+            max_length=self.max_length, padding="max_length",
+        )
+        word_ids = enc.word_ids(batch_index=0)
+
+        a_range = word_span_to_subword_range(word_ids, *a_span)
+        o_range = word_span_to_subword_range(word_ids, *o_span)
+        if a_range is None or o_range is None:
+            self.skipped_truncated += 1
+            # fall back to an all-zero mask -- rare (long-sentence truncation);
+            # the example still trains on sentence context, just without a
+            # located span. Flagged via self.skipped_truncated for reporting.
+
+        item = {k: torch.tensor(v) for k, v in enc.items() if k != "overflow_to_sample_mapping"}
+        item["aspect_mask"] = torch.tensor(build_span_mask(self.max_length, a_range))
+        item["opinion_mask"] = torch.tensor(build_span_mask(self.max_length, o_range))
+        item["label"] = torch.tensor(label_id)
+        return item
+
+
+def collate_fn(batch):
+    return {k: torch.stack([b[k] for b in batch]) for k in batch[0]}

--- a/src/stage3_category/model.py
+++ b/src/stage3_category/model.py
@@ -7,8 +7,8 @@ Reused as-is for Stage 4 (sentiment) -- only num_labels and the label field
 in the dataset differ.
 """
 import torch
-import torch.nn as nn
-from transformers import AutoModel, AutoConfig
+from torch import nn
+from transformers import AutoConfig, AutoModel
 
 
 class PairClassifier(nn.Module):

--- a/src/stage3_category/model.py
+++ b/src/stage3_category/model.py
@@ -1,0 +1,58 @@
+"""
+Shared-encoder span-pair classifier: pools the aspect span and opinion span
+representations (masked mean over their subword tokens) plus the sentence's
+[CLS]/pooled representation, concatenates, and classifies.
+
+Reused as-is for Stage 4 (sentiment) -- only num_labels and the label field
+in the dataset differ.
+"""
+import torch
+import torch.nn as nn
+from transformers import AutoModel, AutoConfig
+
+
+class PairClassifier(nn.Module):
+    def __init__(self, model_name: str, num_labels: int, class_weights: list = None, dropout: float = 0.1):
+        super().__init__()
+        self.config = AutoConfig.from_pretrained(model_name)
+        self.encoder = AutoModel.from_pretrained(model_name)
+        hidden = self.config.hidden_size
+
+        self.dropout = nn.Dropout(dropout)
+        self.classifier = nn.Sequential(
+            nn.Linear(hidden * 3, hidden),  # [aspect_pooled; opinion_pooled; sentence_pooled]
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden, num_labels),
+        )
+
+        self.class_weights = None
+        if class_weights is not None:
+            self.register_buffer("_class_weights", torch.tensor(class_weights, dtype=torch.float))
+            self.class_weights = self._class_weights
+
+    @staticmethod
+    def _masked_mean_pool(hidden_states, mask):
+        # hidden_states: (B, T, H), mask: (B, T)
+        mask = mask.unsqueeze(-1).float()  # (B, T, 1)
+        summed = (hidden_states * mask).sum(dim=1)
+        counts = mask.sum(dim=1).clamp(min=1.0)
+        return summed / counts
+
+    def forward(self, input_ids, attention_mask, aspect_mask, opinion_mask, label=None, **kwargs):
+        out = self.encoder(input_ids=input_ids, attention_mask=attention_mask)
+        seq_out = self.dropout(out.last_hidden_state)  # (B, T, H)
+
+        aspect_pooled = self._masked_mean_pool(seq_out, aspect_mask)
+        opinion_pooled = self._masked_mean_pool(seq_out, opinion_mask)
+        sentence_pooled = self._masked_mean_pool(seq_out, attention_mask)
+
+        combined = torch.cat([aspect_pooled, opinion_pooled, sentence_pooled], dim=-1)
+        logits = self.classifier(combined)
+
+        loss = None
+        if label is not None:
+            loss_fct = nn.CrossEntropyLoss(weight=self.class_weights)
+            loss = loss_fct(logits, label)
+
+        return {"loss": loss, "logits": logits}

--- a/src/stage3_category/model.py
+++ b/src/stage3_category/model.py
@@ -12,7 +12,7 @@ from transformers import AutoModel, AutoConfig
 
 
 class PairClassifier(nn.Module):
-    def __init__(self, model_name: str, num_labels: int, class_weights: list = None, dropout: float = 0.1):
+    def __init__(self, model_name: str, num_labels: int, class_weights: list | None = None, dropout: float = 0.1):
         super().__init__()
         self.config = AutoConfig.from_pretrained(model_name)
         self.encoder = AutoModel.from_pretrained(model_name)

--- a/src/stage3_category/train.py
+++ b/src/stage3_category/train.py
@@ -1,0 +1,193 @@
+"""
+Stage 3 training: category classification (22-class, class-weighted).
+
+Usage (in your GPU environment):
+    pip install -r requirements.txt
+    python train.py --config ../../configs/stage3_afroxlmr.yaml
+
+Reports per-category P/R/F1 (not just macro/micro averages) -- with 10
+low-support categories and 2 with zero explicit-pair training examples,
+averaged metrics alone would hide exactly the failure modes that matter.
+"""
+import argparse
+import json
+import os
+import random
+import numpy as np
+import torch
+import yaml
+from collections import Counter
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer, get_linear_schedule_with_warmup
+from tqdm import tqdm
+
+from dataset import CategoryPairDataset, collate_fn
+from model import PairClassifier
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
+from pair_utils import compute_class_weights
+
+
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def load_config_defaults(config_path):
+    with open(config_path, encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    flat = {"model_name": cfg.get("model_name"), "output_dir": cfg.get("output_dir")}
+    data = cfg.get("data", {})
+    flat.update({"train": data.get("train"), "test": data.get("test"),
+                 "label_space": data.get("label_space"), "max_length": data.get("max_length")})
+    training = cfg.get("training", {})
+    flat.update({"epochs": training.get("epochs"), "batch_size": training.get("batch_size"),
+                 "lr": training.get("lr"), "warmup_ratio": training.get("warmup_ratio"),
+                 "seed": training.get("seed"), "class_weight_cap": training.get("class_weight_cap")})
+    return {k: v for k, v in flat.items() if v is not None}
+
+
+def per_class_prf(y_true, y_pred, id2label):
+    labels = sorted(id2label)
+    counts_tp = Counter()
+    counts_fp = Counter()
+    counts_fn = Counter()
+    for t, p in zip(y_true, y_pred):
+        if t == p:
+            counts_tp[t] += 1
+        else:
+            counts_fp[p] += 1
+            counts_fn[t] += 1
+
+    report = {}
+    macro_f1_sum = 0.0
+    for lid in labels:
+        tp, fp, fn = counts_tp[lid], counts_fp[lid], counts_fn[lid]
+        support = tp + fn
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        report[id2label[lid]] = {"precision": precision, "recall": recall, "f1": f1, "support": support}
+        macro_f1_sum += f1
+    macro_f1 = macro_f1_sum / len(labels) if labels else 0.0
+
+    total_correct = sum(counts_tp.values())
+    accuracy = total_correct / len(y_true) if y_true else 0.0
+    return report, macro_f1, accuracy
+
+
+@torch.no_grad()
+def evaluate(model, dataset, device, id2label, batch_size=32):
+    model.eval()
+    loader = DataLoader(dataset, batch_size=batch_size, collate_fn=collate_fn)
+    y_true, y_pred = [], []
+    for batch in loader:
+        batch = {k: v.to(device) for k, v in batch.items()}
+        out = model(**{k: v for k, v in batch.items() if k != "label"})
+        preds = out["logits"].argmax(-1).cpu().tolist()
+        y_pred.extend(preds)
+        y_true.extend(batch["label"].cpu().tolist())
+    report, macro_f1, accuracy = per_class_prf(y_true, y_pred, id2label)
+    return {"per_category": report, "macro_f1": macro_f1, "accuracy": accuracy}
+
+
+def main():
+    pre = argparse.ArgumentParser(add_help=False)
+    pre.add_argument("--config", default=None)
+    pre_args, remaining_argv = pre.parse_known_args()
+    config_defaults = load_config_defaults(pre_args.config) if pre_args.config else {}
+
+    ap = argparse.ArgumentParser(parents=[pre])
+    ap.add_argument("--train", required="train" not in config_defaults)
+    ap.add_argument("--test", required="test" not in config_defaults)
+    ap.add_argument("--label_space", required="label_space" not in config_defaults,
+                     help="path to label_space.json (defines the fixed category list)")
+    ap.add_argument("--model_name", default="Davlan/afro-xlmr-base")
+    ap.add_argument("--output_dir", default="./stage3_category_ckpt")
+    ap.add_argument("--epochs", type=int, default=10)
+    ap.add_argument("--batch_size", type=int, default=16)
+    ap.add_argument("--lr", type=float, default=2e-5)
+    ap.add_argument("--max_length", type=int, default=256)
+    ap.add_argument("--warmup_ratio", type=float, default=0.1)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--class_weight_cap", type=float, default=15.0)
+    ap.set_defaults(**config_defaults)
+    args = ap.parse_args(remaining_argv)
+
+    set_seed(args.seed)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    os.makedirs(args.output_dir, exist_ok=True)
+    with open(os.path.join(args.output_dir, "resolved_args.json"), "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    with open(args.label_space, encoding="utf-8") as f:
+        label_space = json.load(f)
+    categories = label_space["categories"]
+    label2id = {c: i for i, c in enumerate(categories)}
+    id2label = {i: c for c, i in label2id.items()}
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    train_ds = CategoryPairDataset(args.train, tokenizer, label2id, max_length=args.max_length)
+    test_ds = CategoryPairDataset(args.test, tokenizer, label2id, max_length=args.max_length)
+
+    print(f"Train examples: {len(train_ds)} (skipped {train_ds.skipped_unknown_label} unknown-label, "
+          f"{train_ds.skipped_truncated} truncated-span)")
+    print(f"Test examples: {len(test_ds)} (skipped {test_ds.skipped_unknown_label} unknown-label, "
+          f"{test_ds.skipped_truncated} truncated-span)")
+
+    zero_support = [c for c in categories if not any(lbl == label2id[c] for _, _, _, lbl in train_ds.examples)]
+    if zero_support:
+        print(f"WARNING -- categories with ZERO training examples in this explicit-pairs subset "
+              f"(structurally unlearnable, deferred to Stage 5): {zero_support}")
+
+    train_label_counts = Counter(lbl for _, _, _, lbl in train_ds.examples)
+    weight_by_label = compute_class_weights(
+        {id2label[k]: v for k, v in train_label_counts.items()}, len(categories), cap=args.class_weight_cap
+    )
+    class_weights = [weight_by_label.get(id2label[i], args.class_weight_cap) for i in range(len(categories))]
+
+    model = PairClassifier(args.model_name, num_labels=len(categories), class_weights=class_weights).to(device)
+
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn)
+    total_steps = len(train_loader) * args.epochs
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+    scheduler = get_linear_schedule_with_warmup(
+        optimizer, num_warmup_steps=int(total_steps * args.warmup_ratio), num_training_steps=total_steps
+    )
+
+    best_macro_f1 = -1.0
+    for epoch in range(args.epochs):
+        model.train()
+        pbar = tqdm(train_loader, desc=f"epoch {epoch+1}/{args.epochs}")
+        for batch in pbar:
+            batch = {k: v.to(device) for k, v in batch.items()}
+            out = model(**batch)
+            loss = out["loss"]
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            scheduler.step()
+            optimizer.zero_grad()
+            pbar.set_postfix(loss=loss.item())
+
+        metrics = evaluate(model, test_ds, device, id2label)
+        print(f"\n[epoch {epoch+1}] accuracy={metrics['accuracy']:.4f} macro_f1={metrics['macro_f1']:.4f}")
+
+        if metrics["macro_f1"] > best_macro_f1:
+            best_macro_f1 = metrics["macro_f1"]
+            torch.save(model.state_dict(), os.path.join(args.output_dir, "best_model.pt"))
+            tokenizer.save_pretrained(args.output_dir)
+            with open(os.path.join(args.output_dir, "best_metrics.json"), "w") as f:
+                json.dump(metrics, f, indent=2)
+            print(f"  -> new best (macro F1={best_macro_f1:.4f}), checkpoint saved")
+
+    print(f"\nDone. Best macro F1 = {best_macro_f1:.4f}. Checkpoint: {args.output_dir}/best_model.pt")
+    print("Per-category breakdown of best checkpoint saved to best_metrics.json -- "
+          "check low-support categories specifically, not just the macro average.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/stage3_category/train.py
+++ b/src/stage3_category/train.py
@@ -24,9 +24,9 @@ from tqdm import tqdm
 from transformers import AutoTokenizer, get_linear_schedule_with_warmup
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
-from dataset import CategoryPairDataset, collate_fn  # noqa: E402
-from model import PairClassifier  # noqa: E402
-from pair_utils import compute_class_weights  # noqa: E402
+from dataset import CategoryPairDataset, collate_fn
+from model import PairClassifier
+from pair_utils import compute_class_weights
 
 
 def set_seed(seed: int):

--- a/src/stage3_category/train.py
+++ b/src/stage3_category/train.py
@@ -13,20 +13,20 @@ import argparse
 import json
 import os
 import random
+import sys
+from collections import Counter
+
 import numpy as np
 import torch
 import yaml
-from collections import Counter
 from torch.utils.data import DataLoader
-from transformers import AutoTokenizer, get_linear_schedule_with_warmup
 from tqdm import tqdm
+from transformers import AutoTokenizer, get_linear_schedule_with_warmup
 
-from dataset import CategoryPairDataset, collate_fn
-from model import PairClassifier
-
-import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
-from pair_utils import compute_class_weights
+from dataset import CategoryPairDataset, collate_fn  # noqa: E402
+from model import PairClassifier  # noqa: E402
+from pair_utils import compute_class_weights  # noqa: E402
 
 
 def set_seed(seed: int):

--- a/tests/test_stage3_category.py
+++ b/tests/test_stage3_category.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "common"))
+from pair_utils import (
+    build_span_mask,
+    compute_class_weights,
+    explicit_quads,
+    word_span_to_subword_range,
+)
+
+
+def test_explicit_quads_filter():
+    quads = [
+        {"a_start": 0, "a_end": 1, "o_start": 2, "o_end": 3, "category": "CAT_A"},
+        {"a_start": -1, "a_end": -1, "o_start": 2, "o_end": 3, "category": "CAT_B"},
+        {"a_start": 1, "a_end": 2, "o_start": -1, "o_end": -1, "category": "CAT_C"},
+    ]
+    res = explicit_quads(quads)
+    assert len(res) == 1
+    assert res[0]["category"] == "CAT_A"
+
+
+def test_word_span_to_subword_range():
+    # word_ids: [None, 0, 0, 1, 2, 2, None]
+    word_ids = [None, 0, 0, 1, 2, 2, None]
+    # span [0, 1) -> word 0 -> subwords [1, 2]
+    rng = word_span_to_subword_range(word_ids, 0, 1)
+    assert rng == (1, 2)
+
+    # span [1, 3) -> words 1, 2 -> subwords [3, 5]
+    rng2 = word_span_to_subword_range(word_ids, 1, 3)
+    assert rng2 == (3, 5)
+
+    # out of bounds / truncated word index
+    rng_none = word_span_to_subword_range(word_ids, 10, 12)
+    assert rng_none is None
+
+
+def test_build_span_mask():
+    seq_len = 6
+    mask = build_span_mask(seq_len, (1, 3))
+    assert mask == [0, 1, 1, 1, 0, 0]
+
+    mask_none = build_span_mask(seq_len, None)
+    assert mask_none == [0, 0, 0, 0, 0, 0]
+
+
+def test_compute_class_weights():
+    counts = {"catA": 100, "catB": 10, "catC": 0}
+    weights = compute_class_weights(counts, num_classes=3, cap=15.0)
+    # total = 110
+    # catA: 110 / (3 * 100) = 0.3667
+    # catB: 110 / (3 * 10) = 3.6667
+    # catC: capped at 15.0
+    assert abs(weights["catA"] - 110 / 300) < 1e-4
+    assert abs(weights["catB"] - 110 / 30) < 1e-4
+    assert weights["catC"] == 15.0


### PR DESCRIPTION
Closes #13. Implements Stage 3 per-pair category classification over the fixed 22-category taxonomy with masked mean pooling across aspect, opinion, and sentence representations, plus inverse-frequency class weighting to handle imbalance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Stage 3 category classification for 22 output categories using explicit aspect–opinion pairs.
  - Added configurable training with class balancing, truncation handling, checkpointing, and per-category performance metrics.
  - Added reusable span-pair classification support for future sentiment classification stages.

- **Documentation**
  - Added guidance covering Stage 3 inputs, outputs, model approach, category handling, and class weighting.

- **Tests**
  - Added coverage for span filtering, token-span mapping, masking, and class-weight calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->