### PR TITLE
fix(stage3): ensure class_weights buffer moves to GPU with model

### DIFF
--- a/src/stage3_category/model.py
+++ b/src/stage3_category/model.py
@@ -26,10 +26,10 @@ class PairClassifier(nn.Module):
             nn.Linear(hidden, num_labels),
         )
 
-        self.class_weights = None
         if class_weights is not None:
-            self.register_buffer("_class_weights", torch.tensor(class_weights, dtype=torch.float))
-            self.class_weights = self._class_weights
+            self.register_buffer("class_weights", torch.tensor(class_weights, dtype=torch.float))
+        else:
+            self.class_weights = None
 
     @staticmethod
     def _masked_mean_pool(hidden_states, mask):


### PR DESCRIPTION
## What this PR does


## Related issue
Closes #

## How it was tested


## Checklist
- [ ] Tests pass locally (`pytest tests/`)
- [ ] Config/results committed if this is an experiment
- [ ] README/docs updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of optional class weights during model operation, preserving expected behavior when weights are provided or omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->