### PR TITLE
feat(stage3): add logit adjustment loss and dual macro-F1 evaluation metrics

### DIFF
--- a/configs/stage3_afroxlmr.yaml
+++ b/configs/stage3_afroxlmr.yaml
@@ -29,3 +29,7 @@ notes: >
   see docs/stage3_category_analysis.md. Report per-category P/R/F1, not
   just macro/micro averages -- with this much imbalance, averages hide
   the categories that actually need attention.
+
+# loss_type: logit_adjustment (default, recommended) or class_weighted (older, weaker baseline)
+loss_type: logit_adjustment
+logit_adjustment_tau: 1.0

--- a/configs/stage3_bertsmall.yaml
+++ b/configs/stage3_bertsmall.yaml
@@ -24,3 +24,7 @@ notes: >
   Lightweight Amharic-native baseline for Stage 3 category classification.
   Pretrained on mC4/OSCAR Amharic corpora. Fast to train and evaluate.
   Compare against stage3_afroxlmr.yaml for the multilingual vs monolingual comparison.
+
+# loss_type: logit_adjustment (default, recommended) or class_weighted (older, weaker baseline)
+loss_type: logit_adjustment
+logit_adjustment_tau: 1.0

--- a/src/common/pair_utils.py
+++ b/src/common/pair_utils.py
@@ -42,3 +42,17 @@ def compute_class_weights(label_counts: dict, num_classes: int, cap: float = 15.
         w = total / (num_classes * count) if count > 0 else cap
         weights[label] = min(w, cap)
     return weights
+
+
+def compute_log_priors(label_counts: dict, num_classes: int) -> list[float]:
+    """Empirical log-priors log(P(y)) for logit adjustment (Menon et al., 2021).
+    Adds a small epsilon floor so zero-count classes produce valid finite log-priors."""
+    import math
+
+    total = sum(label_counts.values())
+    priors = []
+    for i in range(num_classes):
+        count = label_counts.get(i, 0)
+        prob = max(count / total, 1e-12) if total > 0 else 1.0 / num_classes
+        priors.append(math.log(prob))
+    return priors

--- a/src/stage3_category/model.py
+++ b/src/stage3_category/model.py
@@ -12,12 +12,21 @@ from transformers import AutoConfig, AutoModel
 
 
 class PairClassifier(nn.Module):
-    def __init__(self, model_name: str, num_labels: int, class_weights: list | None = None, dropout: float = 0.1):
+    def __init__(
+        self,
+        model_name: str,
+        num_labels: int,
+        class_weights: list | None = None,
+        log_priors: list | None = None,
+        tau: float = 1.0,
+        dropout: float = 0.1,
+    ):
         super().__init__()
         self.config = AutoConfig.from_pretrained(model_name)
         self.encoder = AutoModel.from_pretrained(model_name)
         hidden = self.config.hidden_size
 
+        self.tau = tau
         self.dropout = nn.Dropout(dropout)
         self.classifier = nn.Sequential(
             nn.Linear(hidden * 3, hidden),  # [aspect_pooled; opinion_pooled; sentence_pooled]
@@ -30,6 +39,11 @@ class PairClassifier(nn.Module):
             self.register_buffer("class_weights", torch.tensor(class_weights, dtype=torch.float))
         else:
             self.class_weights = None
+
+        if log_priors is not None:
+            self.register_buffer("log_priors", torch.tensor(log_priors, dtype=torch.float))
+        else:
+            self.log_priors = None
 
     @staticmethod
     def _masked_mean_pool(hidden_states, mask):
@@ -52,7 +66,13 @@ class PairClassifier(nn.Module):
 
         loss = None
         if label is not None:
-            loss_fct = nn.CrossEntropyLoss(weight=self.class_weights)
-            loss = loss_fct(logits, label)
+            if self.log_priors is not None:
+                # Logit adjustment: logits + tau * log_priors (Menon et al., 2021)
+                adjusted_logits = logits + self.tau * self.log_priors
+                loss_fct = nn.CrossEntropyLoss(weight=self.class_weights)
+                loss = loss_fct(adjusted_logits, label)
+            else:
+                loss_fct = nn.CrossEntropyLoss(weight=self.class_weights)
+                loss = loss_fct(logits, label)
 
         return {"loss": loss, "logits": logits}

--- a/src/stage3_category/train.py
+++ b/src/stage3_category/train.py
@@ -13,19 +13,19 @@ import argparse
 import json
 import os
 import random
-import sys
-from collections import Counter
-
 import numpy as np
 import torch
 import yaml
+from collections import Counter
 from torch.utils.data import DataLoader
-from tqdm import tqdm
 from transformers import AutoTokenizer, get_linear_schedule_with_warmup
+from tqdm import tqdm
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
 from dataset import CategoryPairDataset, collate_fn
 from model import PairClassifier
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
 from pair_utils import compute_class_weights
 
 
@@ -47,6 +47,8 @@ def load_config_defaults(config_path):
     flat.update({"epochs": training.get("epochs"), "batch_size": training.get("batch_size"),
                  "lr": training.get("lr"), "warmup_ratio": training.get("warmup_ratio"),
                  "seed": training.get("seed"), "class_weight_cap": training.get("class_weight_cap")})
+    flat["loss_type"] = cfg.get("loss_type")
+    flat["logit_adjustment_tau"] = cfg.get("logit_adjustment_tau")
     return {k: v for k, v in flat.items() if v is not None}
 
 
@@ -63,7 +65,7 @@ def per_class_prf(y_true, y_pred, id2label):
             counts_fn[t] += 1
 
     report = {}
-    macro_f1_sum = 0.0
+    present_f1s = []  # only categories that actually appear in this eval set
     for lid in labels:
         tp, fp, fn = counts_tp[lid], counts_fp[lid], counts_fn[lid]
         support = tp + fn
@@ -71,12 +73,27 @@ def per_class_prf(y_true, y_pred, id2label):
         recall = tp / (tp + fn) if (tp + fn) else 0.0
         f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
         report[id2label[lid]] = {"precision": precision, "recall": recall, "f1": f1, "support": support}
-        macro_f1_sum += f1
-    macro_f1 = macro_f1_sum / len(labels) if labels else 0.0
+        if support > 0:
+            present_f1s.append(f1)
+
+    # Two different macro-F1s, both reported -- don't silently pick one:
+    #   macro_f1_all_categories: averages over all 22 categories, including
+    #     ones with zero examples in THIS eval set (forced F1=0). This is
+    #     what earlier versions of this script reported alone, which reads
+    #     as much worse than reality if many categories are simply absent
+    #     from the split being evaluated (common here: the explicit-pairs
+    #     test subset only contains 13-20 of the 22 categories).
+    #   macro_f1_present_categories: averages only over categories that
+    #     actually have test examples -- the more honest "how well does the
+    #     model do on what it's actually being asked to predict" number.
+    all_f1s = [report[id2label[lid]]["f1"] for lid in labels]
+    macro_f1_all = sum(all_f1s) / len(all_f1s) if all_f1s else 0.0
+    macro_f1_present = sum(present_f1s) / len(present_f1s) if present_f1s else 0.0
 
     total_correct = sum(counts_tp.values())
     accuracy = total_correct / len(y_true) if y_true else 0.0
-    return report, macro_f1, accuracy
+    n_absent = len(labels) - len(present_f1s)
+    return report, macro_f1_all, macro_f1_present, n_absent, accuracy
 
 
 @torch.no_grad()
@@ -90,8 +107,14 @@ def evaluate(model, dataset, device, id2label, batch_size=32):
         preds = out["logits"].argmax(-1).cpu().tolist()
         y_pred.extend(preds)
         y_true.extend(batch["label"].cpu().tolist())
-    report, macro_f1, accuracy = per_class_prf(y_true, y_pred, id2label)
-    return {"per_category": report, "macro_f1": macro_f1, "accuracy": accuracy}
+    report, macro_f1_all, macro_f1_present, n_absent, accuracy = per_class_prf(y_true, y_pred, id2label)
+    return {
+        "per_category": report,
+        "macro_f1_all_categories": macro_f1_all,
+        "macro_f1_present_categories": macro_f1_present,
+        "n_categories_absent_from_eval_set": n_absent,
+        "accuracy": accuracy,
+    }
 
 
 def main():
@@ -114,6 +137,12 @@ def main():
     ap.add_argument("--warmup_ratio", type=float, default=0.1)
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("--class_weight_cap", type=float, default=15.0)
+    ap.add_argument("--loss_type", choices=["class_weighted", "logit_adjustment"],
+                     default="logit_adjustment",
+                     help="logit_adjustment (Menon et al. 2021) is the recommended default for "
+                          "severe long-tail imbalance -- class_weighted is the weaker, simpler "
+                          "alternative kept for comparison.")
+    ap.add_argument("--logit_adjustment_tau", type=float, default=1.0)
     ap.set_defaults(**config_defaults)
     args = ap.parse_args(remaining_argv)
 
@@ -144,12 +173,21 @@ def main():
               f"(structurally unlearnable, deferred to Stage 5): {zero_support}")
 
     train_label_counts = Counter(lbl for _, _, _, lbl in train_ds.examples)
-    weight_by_label = compute_class_weights(
-        {id2label[k]: v for k, v in train_label_counts.items()}, len(categories), cap=args.class_weight_cap
-    )
-    class_weights = [weight_by_label.get(id2label[i], args.class_weight_cap) for i in range(len(categories))]
 
-    model = PairClassifier(args.model_name, num_labels=len(categories), class_weights=class_weights).to(device)
+    if args.loss_type == "logit_adjustment":
+        from pair_utils import compute_log_priors
+        log_priors = compute_log_priors(dict(train_label_counts), len(categories))
+        model = PairClassifier(args.model_name, num_labels=len(categories),
+                                log_priors=log_priors, tau=args.logit_adjustment_tau).to(device)
+        print(f"Using logit-adjusted loss (tau={args.logit_adjustment_tau})")
+    else:
+        weight_by_label = compute_class_weights(
+            {id2label[k]: v for k, v in train_label_counts.items()}, len(categories), cap=args.class_weight_cap
+        )
+        class_weights = [weight_by_label.get(id2label[i], args.class_weight_cap) for i in range(len(categories))]
+        model = PairClassifier(args.model_name, num_labels=len(categories),
+                                class_weights=class_weights).to(device)
+        print(f"Using class-weighted loss (cap={args.class_weight_cap})")
 
     train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn)
     total_steps = len(train_loader) * args.epochs
@@ -174,19 +212,22 @@ def main():
             pbar.set_postfix(loss=loss.item())
 
         metrics = evaluate(model, test_ds, device, id2label)
-        print(f"\n[epoch {epoch+1}] accuracy={metrics['accuracy']:.4f} macro_f1={metrics['macro_f1']:.4f}")
+        print(f"\n[epoch {epoch+1}] accuracy={metrics['accuracy']:.4f} "
+              f"macro_f1_present={metrics['macro_f1_present_categories']:.4f} "
+              f"(macro_f1_all_22={metrics['macro_f1_all_categories']:.4f}, "
+              f"{metrics['n_categories_absent_from_eval_set']} categories absent from test)")
 
-        if metrics["macro_f1"] > best_macro_f1:
-            best_macro_f1 = metrics["macro_f1"]
+        if metrics["macro_f1_present_categories"] > best_macro_f1:
+            best_macro_f1 = metrics["macro_f1_present_categories"]
             torch.save(model.state_dict(), os.path.join(args.output_dir, "best_model.pt"))
             tokenizer.save_pretrained(args.output_dir)
             with open(os.path.join(args.output_dir, "best_metrics.json"), "w") as f:
                 json.dump(metrics, f, indent=2)
-            print(f"  -> new best (macro F1={best_macro_f1:.4f}), checkpoint saved")
+            print(f"  -> new best (macro F1 [present categories]={best_macro_f1:.4f}), checkpoint saved")
 
-    print(f"\nDone. Best macro F1 = {best_macro_f1:.4f}. Checkpoint: {args.output_dir}/best_model.pt")
+    print(f"\nDone. Best macro F1 (present categories) = {best_macro_f1:.4f}. Checkpoint: {args.output_dir}/best_model.pt")
     print("Per-category breakdown of best checkpoint saved to best_metrics.json -- "
-          "check low-support categories specifically, not just the macro average.")
+          "check support=0 categories separately from genuinely low-scoring ones with real support.")
 
 
 if __name__ == "__main__":

--- a/src/stage3_category/train.py
+++ b/src/stage3_category/train.py
@@ -13,18 +13,18 @@ import argparse
 import json
 import os
 import random
+import sys
+from collections import Counter
+
 import numpy as np
 import torch
 import yaml
-from collections import Counter
-from torch.utils.data import DataLoader
-from transformers import AutoTokenizer, get_linear_schedule_with_warmup
-from tqdm import tqdm
-
 from dataset import CategoryPairDataset, collate_fn
 from model import PairClassifier
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+from transformers import AutoTokenizer, get_linear_schedule_with_warmup
 
-import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "common"))
 from pair_utils import compute_class_weights
 

--- a/tests/test_stage3_category.py
+++ b/tests/test_stage3_category.py
@@ -5,6 +5,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "common"
 from pair_utils import (
     build_span_mask,
     compute_class_weights,
+    compute_log_priors,
     explicit_quads,
     word_span_to_subword_range,
 )
@@ -56,3 +57,17 @@ def test_compute_class_weights():
     assert abs(weights["catA"] - 110 / 300) < 1e-4
     assert abs(weights["catB"] - 110 / 30) < 1e-4
     assert weights["catC"] == 15.0
+
+
+def test_compute_log_priors():
+    import math
+
+    counts = {0: 100, 1: 10}
+    priors = compute_log_priors(counts, num_classes=3)
+    assert len(priors) == 3
+    # class 0: 100/110
+    assert abs(priors[0] - math.log(100 / 110)) < 1e-4
+    # class 1: 10/110
+    assert abs(priors[1] - math.log(10 / 110)) < 1e-4
+    # class 2 (zero count): epsilon floor
+    assert priors[2] == math.log(1e-12)

--- a/tests/test_stage3_metrics.py
+++ b/tests/test_stage3_metrics.py
@@ -1,0 +1,61 @@
+"""Regression test for the per-category P/R/F1 math used in Stage 3's
+train.py evaluate() -- kept here as a standalone pure-Python copy since
+train.py itself imports torch (not available in every CI environment)."""
+from collections import Counter
+
+
+def per_class_prf(y_true, y_pred, id2label):
+    labels = sorted(id2label)
+    counts_tp, counts_fp, counts_fn = Counter(), Counter(), Counter()
+    for t, p in zip(y_true, y_pred):
+        if t == p:
+            counts_tp[t] += 1
+        else:
+            counts_fp[p] += 1
+            counts_fn[t] += 1
+    report = {}
+    present_f1s = []
+    for lid in labels:
+        tp, fp, fn = counts_tp[lid], counts_fp[lid], counts_fn[lid]
+        support = tp + fn
+        precision = tp / (tp + fp) if (tp + fp) else 0.0
+        recall = tp / (tp + fn) if (tp + fn) else 0.0
+        f1 = 2 * precision * recall / (precision + recall) if (precision + recall) else 0.0
+        report[id2label[lid]] = {"precision": precision, "recall": recall, "f1": f1, "support": support}
+        if support > 0:
+            present_f1s.append(f1)
+    all_f1s = [report[id2label[lid]]["f1"] for lid in labels]
+    macro_f1_all = sum(all_f1s) / len(all_f1s) if all_f1s else 0.0
+    macro_f1_present = sum(present_f1s) / len(present_f1s) if present_f1s else 0.0
+    accuracy = sum(counts_tp.values()) / len(y_true) if y_true else 0.0
+    n_absent = len(labels) - len(present_f1s)
+    return report, macro_f1_all, macro_f1_present, n_absent, accuracy
+
+
+def test_per_class_prf_known_case():
+    id2label = {0: "A", 1: "B"}
+    y_true = [0, 0, 0, 0, 1, 1, 1, 1]
+    y_pred = [0, 0, 0, 0, 1, 1, 0, 0]  # 2 of B's true examples misclassified as A
+    report, macro_f1_all, macro_f1_present, n_absent, acc = per_class_prf(y_true, y_pred, id2label)
+    assert abs(report["A"]["recall"] - 1.0) < 1e-9
+    assert abs(report["A"]["precision"] - 4 / 6) < 1e-9
+    assert abs(report["B"]["recall"] - 0.5) < 1e-9
+    assert abs(report["B"]["precision"] - 1.0) < 1e-9
+    assert acc == 0.75
+    assert n_absent == 0  # both classes present -> macro_f1_all == macro_f1_present
+    assert abs(macro_f1_all - macro_f1_present) < 1e-9
+
+
+def test_per_class_prf_absent_category_does_not_crash_average():
+    # Category "C" never appears in y_true or y_pred at all -- this is the
+    # exact bug this test guards against: an absent category should NOT
+    # silently drag macro_f1_present down to 0 for that category.
+    id2label = {0: "A", 1: "B", 2: "C"}
+    y_true = [0, 0, 1, 1]
+    y_pred = [0, 0, 1, 1]  # perfect predictions on what's actually present
+    report, macro_f1_all, macro_f1_present, n_absent, acc = per_class_prf(y_true, y_pred, id2label)
+    assert report["C"]["support"] == 0
+    assert n_absent == 1
+    assert macro_f1_present == 1.0   # perfect on the 2 categories that exist
+    assert macro_f1_all < macro_f1_present  # dragged down by C's forced zero
+    assert abs(macro_f1_all - 2 / 3) < 1e-9  # (1.0 + 1.0 + 0.0) / 3

--- a/tests/test_stage3_metrics.py
+++ b/tests/test_stage3_metrics.py
@@ -56,6 +56,7 @@ def test_per_class_prf_absent_category_does_not_crash_average():
     report, macro_f1_all, macro_f1_present, n_absent, acc = per_class_prf(y_true, y_pred, id2label)
     assert report["C"]["support"] == 0
     assert n_absent == 1
+    assert acc == 1.0
     assert macro_f1_present == 1.0   # perfect on the 2 categories that exist
     assert macro_f1_all < macro_f1_present  # dragged down by C's forced zero
     assert abs(macro_f1_all - 2 / 3) < 1e-9  # (1.0 + 1.0 + 0.0) / 3


### PR DESCRIPTION
Adds logit adjustment loss (Menon et al., 2021) for Stage 3 category classification to handle long-tail imbalance, adds logit adjustment configuration to both afroxlmr and bertsmall configs, and improves evaluation to report both present-categories and all-22-categories macro-F1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added logit-adjustment loss as the default option for Stage 3 category classification, with configurable adjustment strength.
  * Retained class-weighted loss as an alternative training mode.
  * Enhanced evaluation metrics with macro F1 scores for all categories and evaluated categories, plus absent-category counts.
  * Updated checkpoint selection and reporting to use macro F1 across evaluated categories.

* **Tests**
  * Added coverage for log-prior calculations and category metrics, including evaluations with absent categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->