### PR TITLE
feat(config): switch stage 5 configs to roberta-base amharic

### DIFF
--- a/configs/stage5_category_opinion_anchor.yaml
+++ b/configs/stage5_category_opinion_anchor.yaml
@@ -11,7 +11,7 @@
 #   - stage5_sentiment_fully_implicit.yaml: anchor: none,     subtask: sentiment
 # (just copy this file and change model_name/subtask/anchor/output_dir)
 
-model_name: Davlan/afro-xlmr-base
+model_name: rasyosef/roberta-base-amharic
 subtask: category
 anchor: opinion
 

--- a/configs/stage5_detect_fully_implicit.yaml
+++ b/configs/stage5_detect_fully_implicit.yaml
@@ -2,7 +2,7 @@
 # span at all). 3,324 positive sentences / 35,937 negative in train (8.5%
 # positive) -- similar imbalance level to Stage 4's NEUTRAL class, same
 # reasoning for defaulting to logit adjustment applies.
-model_name: Davlan/afro-xlmr-base
+model_name: rasyosef/roberta-base-amharic
 subtask: detect_fully_implicit
 anchor: none
 

--- a/configs/stage5_detect_implicit_aspect.yaml
+++ b/configs/stage5_detect_implicit_aspect.yaml
@@ -1,7 +1,7 @@
 # Stage 5a — detect implicit aspect (opinion-anchored binary classification)
 # Given an explicit opinion span, does its aspect counterpart exist as a
 # span, or is it implicit? 9,693 positive / 23,617 negative in train.
-model_name: Davlan/afro-xlmr-base
+model_name: rasyosef/roberta-base-amharic
 subtask: detect_implicit_aspect
 anchor: none   # not used for detect_* subtasks -- anchor side is fixed by subtask
 

--- a/configs/stage5_detect_implicit_opinion.yaml
+++ b/configs/stage5_detect_implicit_opinion.yaml
@@ -2,7 +2,7 @@
 # Given an explicit aspect span, is its opinion implicit? 4,560 positive /
 # 23,617 negative in train -- more imbalanced than 5a, logit adjustment
 # matters more here.
-model_name: Davlan/afro-xlmr-base
+model_name: rasyosef/roberta-base-amharic
 subtask: detect_implicit_opinion
 anchor: none
 


### PR DESCRIPTION
Updates all Stage 5 configuration files to use rasyosef/roberta-base-amharic (110M) following its top benchmark performance across Stages 3 and 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated Stage 5 classification and detection workflows to use the `rasyosef/roberta-base-amharic` pretrained model.
  * Applied consistently across implicit-aspect detection, implicit-opinion detection, fully implicit detection, and opinion-anchored category classification.
  * All other training and configuration settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->